### PR TITLE
feat: dts pre-bundle support targeted external

### DIFF
--- a/src/prebundler/config.ts
+++ b/src/prebundler/config.ts
@@ -13,6 +13,7 @@ interface IPreBundleConfig {
     {
       pkg: IApi['pkg'];
       output: string;
+      externals: Record<string, string>;
       maeConfig: ExtractorConfig;
       _maePrepareConfig: IExtractorConfigPrepareOptions;
     }
@@ -57,6 +58,9 @@ function getTypeInfoForPkg(pkgPath: string) {
   return info;
 }
 
+/**
+ * get dts rollup config
+ */
 function getDtsConfig(opts: {
   cwd: string;
   pkgPath: string;
@@ -86,7 +90,7 @@ function getDtsConfig(opts: {
               strict: true,
               skipLibCheck: true,
             },
-            include: [opts.cwd],
+            include: [opts.dtsPath],
           },
         },
         // configure logger
@@ -104,6 +108,7 @@ function getDtsConfig(opts: {
     } as IExtractorConfigPrepareOptions,
     // after externals ready, generate final extractor config below
     maeConfig: undefined as any,
+    externals: undefined as any,
   };
 }
 
@@ -113,6 +118,30 @@ function getDtsConfig(opts: {
  */
 function getDepPkgPath(dep: string, cwd: string) {
   return pkgUp.pkgUpSync({ cwd: require.resolve(dep, { paths: [cwd] }) })!;
+}
+
+/**
+ * get relative externals for specific pre-bundle pkg from other pre-bundle deps
+ * @note  for example, "compiled/a" can be externalized in "compiled/b" as "../a"
+ */
+function getRltExternalsFromDeps(
+  depExternals: Record<string, string>,
+  current: { name: string; output: string },
+) {
+  return Object.entries(depExternals).reduce<Record<string, string>>(
+    (r, [dep, target]) => {
+      // skip self
+      if (dep !== current.name) {
+        // transform dep externals path to relative path
+        r[dep] = winPath(
+          path.relative(path.dirname(current.output), path.dirname(target)),
+        );
+      }
+
+      return r;
+    },
+    {},
+  );
 }
 
 export function getConfig(opts: {
@@ -193,19 +222,10 @@ export function getConfig(opts: {
 
   // process externals for deps
   Object.values(config.deps).forEach((depConfig) => {
-    const rltDepExternals = Object.entries(depExternals).reduce<
-      Record<string, string>
-    >((r, [dep, target]) => {
-      // skip self
-      if (dep !== depConfig.pkg.name) {
-        // transform dep externals path to relative path
-        r[dep] = winPath(
-          path.relative(path.dirname(depConfig.output), path.dirname(target)),
-        );
-      }
-
-      return r;
-    }, {});
+    const rltDepExternals = getRltExternalsFromDeps(depExternals, {
+      name: depConfig.pkg.name!,
+      output: depConfig.output,
+    });
 
     depConfig.nccConfig.externals = {
       ...pkgExternals,
@@ -216,6 +236,11 @@ export function getConfig(opts: {
 
   // process externals for dts
   Object.values(config.dts).forEach((dtsConfig) => {
+    const rltDepExternals = getRltExternalsFromDeps(depExternals, {
+      name: dtsConfig.pkg.name!,
+      output: dtsConfig.output,
+    });
+
     // always skip bundle external pkgs
     dtsConfig._maePrepareConfig.configObject.bundledPackages = Object.keys(
       dtsConfig.pkg.dependencies || {},
@@ -224,6 +249,13 @@ export function getConfig(opts: {
 
       return !depExternals[name] && !extraExternals[name];
     });
+
+    // prepare externals config
+    dtsConfig.externals = {
+      ...pkgExternals,
+      ...rltDepExternals,
+      ...extraExternals,
+    };
 
     // generate the final extract config
     dtsConfig.maeConfig = ExtractorConfig.prepare(dtsConfig._maePrepareConfig);

--- a/src/prebundler/shared.ts
+++ b/src/prebundler/shared.ts
@@ -1,0 +1,19 @@
+const map = new Map();
+
+/**
+ * set data to map key
+ */
+export function setSharedData(key: string, value: any) {
+  map.set(key, value);
+}
+
+/**
+ * get data and clear map key
+ */
+export function getSharedData<T>(key: string): T {
+  const data = map.get(key);
+
+  map.delete(key);
+
+  return data;
+}

--- a/tests/fixtures/prebundle/auto-externals/.fatherrc.ts
+++ b/tests/fixtures/prebundle/auto-externals/.fatherrc.ts
@@ -1,5 +1,5 @@
 export default {
   prebundle: {
-    deps: ['test'],
+    deps: ['test', 'other'],
   },
 };

--- a/tests/fixtures/prebundle/auto-externals/expect.ts
+++ b/tests/fixtures/prebundle/auto-externals/expect.ts
@@ -2,4 +2,8 @@ export default (files: Record<string, string>) => {
   // check auto-external deps in package.json dependencies field
   expect(files['test/index.js']).toContain('require("minimatch")');
   expect(files['test/index.d.ts']).toContain("from 'minimatch'");
+
+  // check auto-external other pre-bundle deps
+  expect(files['test/index.js']).toContain('require("../other")');
+  expect(files['test/index.d.ts']).toContain("from '../other'");
 };

--- a/tests/fixtures/prebundle/auto-externals/node_modules/other/index.d.ts
+++ b/tests/fixtures/prebundle/auto-externals/node_modules/other/index.d.ts
@@ -1,0 +1,1 @@
+export const a: number;

--- a/tests/fixtures/prebundle/auto-externals/node_modules/other/index.js
+++ b/tests/fixtures/prebundle/auto-externals/node_modules/other/index.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/tests/fixtures/prebundle/auto-externals/node_modules/other/package.json
+++ b/tests/fixtures/prebundle/auto-externals/node_modules/other/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "other",
+  "main": "index.js",
+  "types": "index.d.ts"
+}

--- a/tests/fixtures/prebundle/auto-externals/node_modules/test/index.d.ts
+++ b/tests/fixtures/prebundle/auto-externals/node_modules/test/index.d.ts
@@ -1,1 +1,2 @@
 export { default } from 'minimatch';
+export { a } from 'other';

--- a/tests/fixtures/prebundle/auto-externals/node_modules/test/index.js
+++ b/tests/fixtures/prebundle/auto-externals/node_modules/test/index.js
@@ -1,1 +1,2 @@
 export { default } from 'minimatch';
+export { a } from 'other';

--- a/tests/fixtures/prebundle/auto-externals/node_modules/test/package.json
+++ b/tests/fixtures/prebundle/auto-externals/node_modules/test/package.json
@@ -3,6 +3,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "minimatch": "3.1.2"
+    "minimatch": "3.1.2",
+    "other": "0.0.0"
   }
 }

--- a/tests/fixtures/prebundle/extra-externals/.fatherrc.ts
+++ b/tests/fixtures/prebundle/extra-externals/.fatherrc.ts
@@ -3,6 +3,7 @@ export default {
     deps: ['test'],
     extraExternals: {
       minimatch: 'minimatch',
+      hello: 'world',
     },
   },
 };

--- a/tests/fixtures/prebundle/extra-externals/expect.ts
+++ b/tests/fixtures/prebundle/extra-externals/expect.ts
@@ -1,5 +1,9 @@
 export default (files: Record<string, string>) => {
-  // check auto-external deps in package.json dependencies field
+  // check normal extra externals
   expect(files['test/index.js']).toContain('require("minimatch")');
   expect(files['test/index.d.ts']).toContain("from 'minimatch'");
+
+  // check targeted extra externals
+  expect(files['test/index.js']).toContain('require("world")');
+  expect(files['test/index.d.ts']).toContain("from 'world'");
 };

--- a/tests/fixtures/prebundle/extra-externals/node_modules/test/index.d.ts
+++ b/tests/fixtures/prebundle/extra-externals/node_modules/test/index.d.ts
@@ -1,1 +1,3 @@
 export { default } from 'minimatch';
+// @ts-ignore
+export { a } from 'hello';

--- a/tests/fixtures/prebundle/extra-externals/node_modules/test/index.js
+++ b/tests/fixtures/prebundle/extra-externals/node_modules/test/index.js
@@ -1,1 +1,2 @@
 export { default } from 'minimatch';
+export { a } from 'hello';

--- a/tests/fixtures/prebundle/extra-externals/node_modules/test/package.json
+++ b/tests/fixtures/prebundle/extra-externals/node_modules/test/package.json
@@ -3,6 +3,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "minimatch": "3.1.2"
+    "minimatch": "3.1.2",
+    "world": "0.0.0"
   }
 }


### PR DESCRIPTION
- 依赖的类型预打包支持定向 `extraExternals` 配置，比如 `{ a: 'b' }`
- 依赖的类型预打包支持自动 external 本地预打包的其他依赖，比如 a 依赖 b 并且两者都被预打包，那么 `compiled/a/index.js` 将直接从 `../b` 依赖 b