### PR TITLE
docs: 多余命令删除

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -9,7 +9,6 @@ father 是一款组件/库打包工具，可以帮助开发者将项目源码输
 通过 `create-father` 快速创建一个 father 项目：
 
 ```bash
-$ mkdir test-father-4
 $ npx create-father test-father-4
 ```
 


### PR DESCRIPTION
这个命令应该是多余的
或者应该是？
```bash
$ mkdir test-father-4
$ cd test-father-4
$ npx create-father 
```
```bash
$ npx create-father test-father-4
```
这两个等效