### PR TITLE
chore: migrate prettier config

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  printWidth: 80,
+  singleQuote: true,
+  trailingComma: 'all',
+  proseWrap: 'never',
+  overrides: [
+    {
+      files: '.prettierrc',
+      options: {
+        parser: 'json',
+      },
+    },
+  ],
+  plugins: [
+    require.resolve('prettier-plugin-packagejson'),
+    require.resolve('prettier-plugin-packagejson'),
+  ],
+};

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -12,7 +12,7 @@ module.exports = {
     },
   ],
   plugins: [
-    require.resolve('prettier-plugin-packagejson'),
+    require.resolve('prettier-plugin-organize-imports'),
     require.resolve('prettier-plugin-packagejson'),
   ],
 };

--- a/package.json
+++ b/package.json
@@ -41,17 +41,6 @@
       "prettier --parser=typescript --write"
     ]
   },
-  "prettier": {
-    "pluginSearchDirs": false,
-    "plugins": [
-      "prettier-plugin-organize-imports",
-      "prettier-plugin-packagejson"
-    ],
-    "printWidth": 80,
-    "proseWrap": "never",
-    "singleQuote": true,
-    "trailingComma": "all"
-  },
   "dependencies": {
     "@microsoft/api-extractor": "7.25.1",
     "@umijs/babel-preset-umi": "^4.0.0",


### PR DESCRIPTION
用 prettier 格式化失效了，搜了一下 umi 也有这个问题，按照 [#8182](https://github.com/umijs/umi/issues/8182#issuecomment-1171840512) 的方式 workground 解决